### PR TITLE
React Router Initial Setup for Dev Server

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -87,6 +87,9 @@ module.exports = (env, argv) => {
   }
 
   return {
+    output: {
+      publicPath: '/'
+    },
     module: {
       rules: [
         /* This will make the babel-loader handle all .js files. We have set up two presets in
@@ -161,6 +164,9 @@ module.exports = (env, argv) => {
         }
       ]
     },
-    plugins: plugins
+    plugins: plugins,
+    devServer: {
+      historyApiFallback: true
+    }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,27 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import { Provider } from "react-redux";
-import { BrowserRouter, Switch, Route } from "react-router-dom";
-import createStore from "./redux/store";
-import "./styles/index.scss";
-import HomeRoute from "./views/home/home";
-import AboutView from "./views/about/about";
-import NoMatch from "./views/nomatch/nomatch";
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Provider } from 'react-redux'
+import { BrowserRouter, Switch, Route } from 'react-router-dom'
+import createStore from './redux/store'
+import './styles/index.scss'
+import HomeRoute from './views/home/home'
+import AboutView from './views/about/about'
+import NoMatch from './views/nomatch/nomatch'
 
-const store = createStore();
+const store = createStore()
 
 const AppRender = props => {
   return (
     <Provider store={store}>
       <BrowserRouter>
         <Switch>
-          <Route path="/about" component={AboutView} />
-          <Route path="/" exact component={HomeRoute} />
+          <Route path='/about' component={AboutView} />
+          <Route path='/' exact component={HomeRoute} />
           <Route component={NoMatch} />
         </Switch>
       </BrowserRouter>
     </Provider>
-  );
-};
+  )
+}
 
-ReactDOM.render(<AppRender />, document.getElementById("root"));
+ReactDOM.render(<AppRender />, document.getElementById('root'))

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,27 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import {Provider} from 'react-redux'
-import {BrowserRouter, Switch, Route} from 'react-router-dom'
-import createStore from './redux/store'
-import './styles/index.scss'
-import HomeRoute from './views/home/home'
-import AboutView from './views/about/about'
+import React from "react";
+import ReactDOM from "react-dom";
+import { Provider } from "react-redux";
+import { BrowserRouter, Switch, Route } from "react-router-dom";
+import createStore from "./redux/store";
+import "./styles/index.scss";
+import HomeRoute from "./views/home/home";
+import AboutView from "./views/about/about";
+import NoMatch from "./views/nomatch/nomatch";
 
-const store = createStore()
+const store = createStore();
 
-const AppRender = (props) => {
+const AppRender = props => {
   return (
     <Provider store={store}>
       <BrowserRouter>
         <Switch>
-          <Route path='/about' component={AboutView} />
-          <Route path='/' exact component={HomeRoute} />
+          <Route path="/about" component={AboutView} />
+          <Route path="/" exact component={HomeRoute} />
+          <Route component={NoMatch} />
         </Switch>
       </BrowserRouter>
     </Provider>
-  )
-}
+  );
+};
 
-ReactDOM.render(
-  <AppRender />,
-  document.getElementById('root')
-)
+ReactDOM.render(<AppRender />, document.getElementById("root"));

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,23 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import {Provider} from 'react-redux'
+import {BrowserRouter, Switch, Route} from 'react-router-dom'
 import createStore from './redux/store'
 import './styles/index.scss'
 import HomeRoute from './views/home/home'
+import AboutView from './views/about/about'
 
 const store = createStore()
 
 const AppRender = (props) => {
   return (
     <Provider store={store}>
-      <HomeRoute />
+      <BrowserRouter>
+        <Switch>
+          <Route path='/about' component={AboutView} />
+          <Route path='/' exact component={HomeRoute} />
+        </Switch>
+      </BrowserRouter>
     </Provider>
   )
 }

--- a/src/views/about/about.js
+++ b/src/views/about/about.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import styles from './about.scss'
+
+class AboutView extends React.Component {
+  render () {
+    return (
+      <div className={styles.about}>
+        <h1>About!</h1>
+      </div>
+    )
+  }
+}
+
+export default AboutView

--- a/src/views/about/about.scss
+++ b/src/views/about/about.scss
@@ -1,0 +1,3 @@
+.about {
+  background-color: $primaryColor;
+}

--- a/src/views/nomatch/nomatch.js
+++ b/src/views/nomatch/nomatch.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const NoMatch = () => (
+  <div>
+    <h1>404 - We can't find that page.</h1>
+    <ul>
+      <li>
+        <Link to="/">Home</Link>
+      </li>
+      <li>
+        <Link to="/about">About page</Link>
+      </li>
+    </ul>
+  </div>
+);
+
+export default NoMatch;

--- a/src/views/nomatch/nomatch.js
+++ b/src/views/nomatch/nomatch.js
@@ -1,32 +1,20 @@
 import React from 'react'
 import {
-  BrowserRouter as Router,
-  Route,
-  Link,
-  Switch
+  Link
 } from 'react-router-dom'
-import HomeRoute from '../home/home'
-import AboutView from '../about/about'
 
 const NoMatch = () => (
-  <Router>
-    <div>
-      <h1>404 - We can't find that page.</h1>
-      <ul>
-        <li>
-          <Link to='/'>Home</Link>
-        </li>
-        <li>
-          <Link to='/about'>About page</Link>
-        </li>
-      </ul>
-      <Switch>
-        <Route path='/' exact component={HomeRoute} />
-        <Route path='/about' component={AboutView} />
-        <Route component={NoMatch} />
-      </Switch>
-    </div>
-  </Router>
+  <div>
+    <h1>404 - We can't find that page.</h1>
+    <ul>
+      <li>
+        <Link to='/'>Home</Link>
+      </li>
+      <li>
+        <Link to='/about'>About page</Link>
+      </li>
+    </ul>
+  </div>
 )
 
 export default NoMatch

--- a/src/views/nomatch/nomatch.js
+++ b/src/views/nomatch/nomatch.js
@@ -1,18 +1,32 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React from 'react'
+import {
+  BrowserRouter as Router,
+  Route,
+  Link,
+  Switch
+} from 'react-router-dom'
+import HomeRoute from '../home/home'
+import AboutView from '../about/about'
 
 const NoMatch = () => (
-  <div>
-    <h1>404 - We can't find that page.</h1>
-    <ul>
-      <li>
-        <Link to="/">Home</Link>
-      </li>
-      <li>
-        <Link to="/about">About page</Link>
-      </li>
-    </ul>
-  </div>
-);
+  <Router>
+    <div>
+      <h1>404 - We can't find that page.</h1>
+      <ul>
+        <li>
+          <Link to='/'>Home</Link>
+        </li>
+        <li>
+          <Link to='/about'>About page</Link>
+        </li>
+      </ul>
+      <Switch>
+        <Route path='/' exact component={HomeRoute} />
+        <Route path='/about' component={AboutView} />
+        <Route component={NoMatch} />
+      </Switch>
+    </div>
+  </Router>
+)
 
-export default NoMatch;
+export default NoMatch


### PR DESCRIPTION
…ck config to allow routes to work as expected.

Per [this article](https://tylermcginnis.com/react-router-cannot-get-url-refresh/). And the errors we were seeing when trying to go to /about, I added

```
output: {
  publicPath: '/'
}
```

and
```
devServer: {
      historyApiFallback: true
}
```

to webpack config. This prevents the dev-server from assuming that all routes are GETs to different html files in the build, and thus allows react-router to take control.

## To Test:
Pull, build, and see if going to /about works.

Solves #14 For Dev. ~Unsure about Prod effects.~