### PR TITLE
Fixed some poor inflections in our templates

### DIFF
--- a/_templates/component/new/class.ejs.t
+++ b/_templates/component/new/class.ejs.t
@@ -4,7 +4,7 @@ to: "<%= locals.functional ? null : 'src/components/' + h.inflection.camelize(na
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import styles from './<%= h.inflection.dasherize(name) %>.scss'
+import styles from './<%= h.inflection.dasherize(h.inflection.underscore(name)) %>.scss'
 
 class <%= h.inflection.camelize(name) %> extends Component {
   render () {

--- a/_templates/component/new/functional.ejs.t
+++ b/_templates/component/new/functional.ejs.t
@@ -4,7 +4,7 @@ to: "<%= locals.functional ? 'src/components/' + h.inflection.camelize(name, tru
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import styles from './<%= h.inflection.dasherize(name) %>.scss'
+import styles from './<%= h.inflection.dasherize(h.inflection.underscore(name)) %>.scss'
 
 function <%= h.inflection.camelize(name) %> (props) {
   return (

--- a/_templates/component/new/styles.ejs.t
+++ b/_templates/component/new/styles.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: src/components/<%= h.inflection.camelize(name, true) %>/<%= h.inflection.dasherize(name) %>.scss
+to: src/components/<%= h.inflection.camelize(name, true) %>/<%= h.inflection.dasherize(h.inflection.underscore(name)) %>.scss
 ---
 
 .<%= h.inflection.camelize(name, true) %>Wrapper {

--- a/_templates/container/new/smartComponent.ejs.t
+++ b/_templates/container/new/smartComponent.ejs.t
@@ -13,7 +13,7 @@ import {actionCreators} from '../../redux/<%= duck %>'
 <% }else{ -%>
 import {actionCreators} from '../../redux/duck'
 <% } -%>
-import styles from './<%= h.inflection.dasherize(name) %>-container.scss'
+import styles from './<%= h.inflection.dasherize(h.inflection.underscore(name)) %>-container.scss'
 
 <% if(locals.functional){ -%>
 function <%= h.inflection.camelize(name) %> (props) {

--- a/_templates/container/new/styles.ejs.t
+++ b/_templates/container/new/styles.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: src/containers/<%= h.inflection.camelize(name, true) %>/<%= h.inflection.dasherize(name) %>-container.scss
+to: src/containers/<%= h.inflection.camelize(name, true) %>/<%= h.inflection.dasherize(h.inflection.underscore(name)) %>-container.scss
 ---
 
 .<%= h.inflection.camelize(name, true) %>Wrapper {

--- a/_templates/duck/new/tests.ejs.t
+++ b/_templates/duck/new/tests.ejs.t
@@ -21,7 +21,7 @@ describe('types', () => {
 <% } -%>
 })
 
-describe('<%= h.inflection.humanize(name) %> Reducer', () => {
+describe('<%= h.inflection.titleize(h.inflection.humanize(h.inflection.underscore(name))) %> Reducer', () => {
 <% if(locals.dummy){ -%>
   it('should reduce quack', () => {
     const quack = actionCreators.quack(true)

--- a/_templates/duck/newAction/action.ejs.t
+++ b/_templates/duck/newAction/action.ejs.t
@@ -2,9 +2,9 @@
 inject: true
 to: src/redux/<%= h.inflection.camelize(duck, true) %>/<%= h.inflection.camelize(duck, true) %>Actions.js
 before: export const actionCreators = {
-skip_if: const <%= h.inflection.camelize(name, true) %> = 
+skip_if: const <%= h.inflection.underscore(name).toUpperCase() %> = 
 ---
 const <%= h.inflection.camelize(name, true) %> = (payload) => ({
-  type: types.<%= h.inflection.underscore(name, true) %>,
+  type: types.<%= h.inflection.underscore(name).toUpperCase() %>,
   payload: payload
 })

--- a/_templates/duck/newAction/testTypes.ejs.t
+++ b/_templates/duck/newAction/testTypes.ejs.t
@@ -7,7 +7,7 @@ skip_if: it\('should create <%= h.inflection.camelize(name, true) %> action'
   it('should create <%= h.inflection.camelize(name, true) %> action', () => {
     expect(actionCreators.<%= h.inflection.camelize(name, true) %>())
       .toEqual({
-        type: types.<%= h.inflection.underscore(name, true) %>,
+        type: types.<%= h.inflection.underscore(name).toUpperCase() %>,
         payload: undefined
       })
   })

--- a/_templates/duck/newAction/type.ejs.t
+++ b/_templates/duck/newAction/type.ejs.t
@@ -2,6 +2,6 @@
 inject: true
 to: src/redux/<%= h.inflection.camelize(duck, true) %>/<%= h.inflection.camelize(duck, true) %>Actions.js
 before: export const types = {
-skip_if: const <%= h.inflection.underscore(name, true) %> =
+skip_if: const <%= h.inflection.underscore(name).toUpperCase() %> =
 ---
-const <%= h.inflection.underscore(name, true) %> = 'exampleApp/<%= h.inflection.camelize(duck, true) %>/<%= h.inflection.underscore(name, true) %>'
+const <%= h.inflection.underscore(name).toUpperCase() %> = 'exampleApp/<%= h.inflection.camelize(duck, true) %>/<%= h.inflection.underscore(name).toUpperCase() %>'

--- a/_templates/duck/newAction/typeExport.ejs.t
+++ b/_templates/duck/newAction/typeExport.ejs.t
@@ -2,6 +2,6 @@
 inject: true
 to: src/redux/<%= h.inflection.camelize(duck, true) %>/<%= h.inflection.camelize(duck, true) %>Actions.js
 after: export const types = {
-skip_if: <%= h.inflection.underscore(name, true) %>,
+skip_if: \s\s<%= h.inflection.underscore(name).toUpperCase() %>,
 ---
-  <%= h.inflection.underscore(name, true) %>,
+  <%= h.inflection.underscore(name).toUpperCase() %>,


### PR DESCRIPTION
Fixes #21 , Fixes #20 , Fixes #22 .

- Properly inflects things in multiple steps, since these functions only perform a single transition (e.g. camelCase -> snake_case) and a few of our needs require multiple transitions.
- Fixed regex for skipping the Type export injection.