### PR TITLE
Enables Class Properties in Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,6 @@
       "shippedProposals": true
     }],
     "@babel/preset-react"
-  ]
+  ],
+  "plugins": ["transform-class-properties"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -539,6 +539,26 @@
         }
       }
     },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
     "@babel/helper-hoist-variables": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.44.tgz",
@@ -1214,6 +1234,17 @@
         "@babel/plugin-syntax-async-generators": "7.0.0-beta.44"
       }
     },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.44.tgz",
+      "integrity": "sha512-IQ9kUIPg4iKDPkVKHvN8EAiRa5qH6+fUqzWPMtsDzmXD2Rpdj0FtR/I0rJkqcutYxneNwfDJFsgTvmFixClSww==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/plugin-syntax-class-properties": "7.0.0-beta.44"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.44.tgz",
@@ -1286,6 +1317,15 @@
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.44.tgz",
       "integrity": "sha512-42MXWQvAN2IPPcW4HUbqgeyqkAwAsCGIHzxgSYoI7aOgkfOwHf5LRqSlJ56HAH+WwlWDQUvXeT/2PrQQY1vSCw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.44.tgz",
+      "integrity": "sha512-lyojjfVoXuL+Oa95TSVWyf5fMO+JzvMpbFQaZN+voWajMt+Cq3lx8N5JszjlcQzBOZOffqjzMxlAKhNVw95ufA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.44"
@@ -1963,6 +2003,95 @@
         "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.44"
       }
     },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.44"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "3.1.0",
+        "globals": "11.4.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.44"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        },
+        "globals": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -2442,6 +2571,37 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
       "dev": true
+    },
+    "babel-eslint": {
+      "version": "8.2.2",
+      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+      "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.44"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
+      }
     },
     "babel-generator": {
       "version": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "webpack-dev-server --mode development --open --config config/webpack.config.js",
     "dist": "npx webpack --config config/webpack.config.js --mode production",
-    "test": "standard && jest"
+    "test": "standard && jest",
+    "lint": "standard"
   },
   "repository": {
     "type": "git",
@@ -24,11 +25,13 @@
   "homepage": "https://github.com/RobotsAndPencils/react-gantry#readme",
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.44",
+    "@babel/plugin-proposal-class-properties": "^7.0.0-beta.44",
     "@babel/preset-env": "^7.0.0-beta.44",
     "@babel/preset-react": "^7.0.0-beta.44",
     "autoprefixer": "^7.2.5",
     "axios-mock-adapter": "^1.14.1",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-eslint": "^8.2.2",
     "babel-jest": "^22.2.0",
     "babel-loader": "^7.1.2",
     "css-loader": "^0.28.9",
@@ -66,6 +69,7 @@
     "redux-thunk": "^2.2.0"
   },
   "standard": {
+    "parser": "babel-eslint",
     "env": [
       "jest"
     ]

--- a/src/containers/profile/profileContainer.js
+++ b/src/containers/profile/profileContainer.js
@@ -8,7 +8,7 @@ import Gear from '../../assets/svg/repairing-service.svg'
 import gearSrc from '../../assets/svg/repairing-service.svg?external'
 
 export class Profile extends React.Component {
-  getProfileDetails () {
+  getProfileDetails = () => {
     this.props.randomName()
     this.props.getSkills()
   }
@@ -30,7 +30,7 @@ export class Profile extends React.Component {
           <Avatar name={this.props.name} set={2} />
           <Avatar name={this.props.name} set={3} />
         </figure>
-        <button onClick={() => this.getProfileDetails()}>Give me a Name!</button>
+        <button onClick={this.getProfileDetails}>Give me a Name!</button>
         <h2>Skills</h2>
         {
           this.props.skills.map((skill) => {

--- a/src/containers/profile/profileContainer.test.js
+++ b/src/containers/profile/profileContainer.test.js
@@ -3,7 +3,14 @@ import {shallow} from 'enzyme'
 import {Profile} from './profileContainer'
 
 describe('with a name prop', () => {
-  const profile = shallow(<Profile name='test' />)
+  const randomName = jest.fn()
+  const getSkills = jest.fn()
+  const profile = shallow(
+    <Profile
+      name='test'
+      randomName={randomName}
+      getSkills={getSkills} />
+  )
   it('should render without crashing', () => {
     expect(profile.length).toBe(1)
   })


### PR DESCRIPTION
- Adds [Class Properties](https://github.com/tc39/proposal-class-fields) in Babel
- Fixes Standard to use babel-eslint as a parser so that it doens't complain about said class properties.