### PR TITLE
Added Jest test debugging in vsCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "--watch"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}


### PR DESCRIPTION
This Adds a .vscode directory with a launch.json config file per the [example here](http://jestjs.io/docs/en/troubleshooting.html#debugging-in-vs-code).

It'll allow you to run tests with debugging enabled within VSCode.

To Test:
1. Start the debugger in VSCode "Debug Jest Tests".
2. Add a breakpoint to a test file (click to the left of the line number)
3. In the vscode terminal, hit `a` to run all tests. By default it will watch only the files that have changed from the last commit.
